### PR TITLE
Drop support for Ruby 2.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1'] }
+      matrix: { ruby: ['3.0', '3.1', '3.2', head] }
 
     steps:
     - name: Checkout code

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+require:
+  - rubocop-performance
+  - rubocop-rspec
+
+inherit_gem:
+  rentacop:
+    - rentacop.yml
+    - rspec.yml
+
+AllCops:
+  TargetRubyVersion: 3.0
+  Exclude:
+    - dev/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,11 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem 'runfile'
-gem 'runfile-tasks'
-gem 'rspec'
-gem 'simplecov'
-gem 'lp'
 gem 'byebug'
 gem 'docspec'
+gem 'lp'
+gem 'rspec'
+gem 'runfile'
+gem 'runfile-tasks'
+gem 'simplecov'
 
 gemspec
-

--- a/Runfile
+++ b/Runfile
@@ -1,9 +1,4 @@
-require "runfile-tasks"
-require_relative 'lib/getcomments'
-
 title   "GetComments Developer Toolbelt"
 summary "Runfile tasks for building the GetComments gem"
-version GetComments::VERSION
 
-RunfileTasks::RubyGems.all 'getcomments'
-RunfileTasks::Testing.rspec
+import_gem 'runfile-tasks/gem'

--- a/getcomments.gemspec
+++ b/getcomments.gemspec
@@ -1,18 +1,18 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'date'
 require 'getcomments/version'
 
 Gem::Specification.new do |s|
   s.name        = 'getcomments'
   s.version     = GetComments::VERSION
-  s.date        = Date.today.to_s
-  s.summary     = "Extract comments from a Ruby source file"
-  s.description = "Extract comments from a Ruby source file"
-  s.authors     = ["Danny Ben Shitrit"]
+  s.summary     = 'Extract comments from a Ruby source file'
+  s.description = 'Extract comments from a Ruby source file'
+  s.authors     = ['Danny Ben Shitrit']
   s.email       = 'db@dannyben.com'
   s.files       = Dir['README.md', 'lib/**/*.*']
   s.homepage    = 'https://github.com/DannyBen/getcomments'
   s.license     = 'MIT'
-  s.required_ruby_version = ">= 2.2.2"
+
+  s.required_ruby_version = '>= 3.0'
+  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/getcomments/code.rb
+++ b/lib/getcomments/code.rb
@@ -39,8 +39,8 @@ module GetComments
       @lines ||= code.lines
     end
 
-    def get_key(line='')
-      if match = line.match(/^([\w_]+ [\w\:]+)/)
+    def get_key(line = '')
+      if (match = line.match(/^([\w_]+ [\w:]+)/))
         match.captures.first
       else
         @comment_index += 1
@@ -48,5 +48,4 @@ module GetComments
       end
     end
   end
-
 end

--- a/lib/getcomments/version.rb
+++ b/lib/getcomments/version.rb
@@ -1,3 +1,3 @@
 module GetComments
-  VERSION = "0.2.0"
+  VERSION = '0.2.0'
 end

--- a/spec/fixtures/basic.rb
+++ b/spec/fixtures/basic.rb
@@ -1,9 +1,7 @@
 # Module comment
 module TestModule
-
   # Class comment
   class TestClass
-
     # Attribute comment
     attr_reader :some_attr
 
@@ -14,12 +12,10 @@ module TestModule
     #   as if it is code
     def some_method(with:, args:)
       # Floating comment
-
     end
 
     # Method comment
-    def another_method
-    end
+    def another_method; end
 
     # Another floating comment
   end

--- a/spec/fixtures/minimal.rb
+++ b/spec/fixtures/minimal.rb
@@ -1,14 +1,11 @@
 # Module comment
 module TestModule
-
   # Class comment
   class TestClass
-
     # Attribute comment
     attr_reader :some_attr
 
     # Method comment
-    def some_method(with:, args:)
-    end
+    def some_method(with:, args:); end
   end
 end

--- a/spec/getcomments/code_spec.rb
+++ b/spec/getcomments/code_spec.rb
@@ -1,43 +1,44 @@
 require 'spec_helper'
 
 describe Code do
-  let(:code) { File.read 'spec/fixtures/basic.rb' }
-  let(:subject) { described_class.new code }
+  subject { described_class.new code }
 
-  describe "#comments" do
+  let(:code) { File.read 'spec/fixtures/basic.rb' }
+
+  describe '#comments' do
     let(:result) { subject.comments }
 
-    it "returns a hash" do
+    it 'returns a hash' do
       expect(result).to be_a Hash
     end
 
-    it "respects indented comments" do
+    it 'respects indented comments' do
       expect(result['def some_method']).to match(/  With indented example/)
     end
 
-    it "captures comments for module" do
-      expect(result['module TestModule']).to eq "Module comment"
+    it 'captures comments for module' do
+      expect(result['module TestModule']).to eq 'Module comment'
     end
 
-    it "captures comments for class" do
-      expect(result['class TestClass']).to eq "Class comment"
+    it 'captures comments for class' do
+      expect(result['class TestClass']).to eq 'Class comment'
     end
 
-    it "captures comments for def" do
-      expect(result['def another_method']).to eq "Method comment"
+    it 'captures comments for def' do
+      expect(result['def another_method']).to eq 'Method comment'
     end
 
-    it "captures comments for attr accessors" do
-      expect(result['attr_reader :some_attr']).to eq "Attribute comment"
+    it 'captures comments for attr accessors' do
+      expect(result['attr_reader :some_attr']).to eq 'Attribute comment'
     end
 
-    it "captures floating comments" do
-      expect(result['comment_1']).to eq "Floating comment"
-      expect(result['comment_2']).to eq "Another floating comment"
+    it 'captures floating comments' do
+      expect(result['comment_1']).to eq 'Floating comment'
+      expect(result['comment_2']).to eq 'Another floating comment'
     end
 
-    it "captures end of file comments" do
-      expect(result['comment_3']).to eq "EOF comment"
+    it 'captures end of file comments' do
+      expect(result['comment_3']).to eq 'EOF comment'
     end
   end
 end

--- a/spec/getcomments/get_comments_spec.rb
+++ b/spec/getcomments/get_comments_spec.rb
@@ -3,21 +3,21 @@ require 'spec_helper'
 describe GetComments do
   subject { described_class }
 
-  describe "::from_file" do
+  describe '::from_file' do
     let(:filename) { 'spec/fixtures/minimal.rb' }
 
-    it "returns comments from the file" do
+    it 'returns comments from the file' do
       comments = subject.from_file filename
-      expect(comments["module TestModule"]).to eq "Module comment"
+      expect(comments['module TestModule']).to eq 'Module comment'
     end
   end
 
-  describe "::from_string" do
+  describe '::from_string' do
     let(:code) { "# the comment\ndef function\n" }
 
-    it "returns comments from the string" do
+    it 'returns comments from the string' do
       comments = subject.from_string code
-      expect(comments["def function"]).to eq "the comment"
+      expect(comments['def function']).to eq 'the comment'
     end
   end
 end


### PR DESCRIPTION
- Drop support for Ruby 2.x
- Comply with Rubocop standards
- Update Runfile syntax